### PR TITLE
feat: add font size customization

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -4,6 +4,16 @@ const exclusionSelectors = {
 
 const currentDomain = window.location.hostname;
 
+const SKIP_SELECTOR =
+  'i,[class*="icon"],[class*="fa-"],svg,code,pre,kbd,samp,h1,h2,h3,h4,h5,h6,button';
+function shouldSkip(el) {
+  if (el.closest('.app-banner')) return true;
+  if (el.closest('.byline-wrapper')) return true;
+  if (el.closest('.byline')) return true;
+  if (el.closest('.titleContainer-DJYq5v')) return true;
+  return el.matches(SKIP_SELECTOR);
+}
+
 const changeFontFamily = (
   node,
   serif,
@@ -12,15 +22,20 @@ const changeFontFamily = (
   serifWeight,
   sansSerifWeight,
   monospaceWeight,
+  serifSize,
+  sansSerifSize,
+  monospaceSize,
 ) => {
-  if (
-    node.nodeType === 1 &&
-    exclusionSelectors[currentDomain] &&
-    exclusionSelectors[currentDomain].some((selector) => node.matches(selector))
-  ) {
-    return;
-  }
   if (node.nodeType === 1) {
+    if (
+      (exclusionSelectors[currentDomain] &&
+        exclusionSelectors[currentDomain].some((selector) =>
+          node.matches(selector),
+        )) ||
+      shouldSkip(node)
+    ) {
+      return;
+    }
     const computedStyle = window.getComputedStyle(node);
     const fontFamily = computedStyle.getPropertyValue("font-family");
     if (fontFamily) {
@@ -57,14 +72,21 @@ const changeFontFamily = (
         if (!applied && sansSerifTriggers.includes(font) && sansSerif != "Default") {
           node.style.fontFamily = `'${sansSerif}'`;
           node.style.fontWeight = sansSerifWeight !== "Default" ? sansSerifWeight : "";
+          node.style.fontSize =
+            sansSerifSize !== "Default" ? `${sansSerifSize}px` : "";
           applied = true;
         } else if (!applied && serifTriggers.includes(font) && serif != "Default") {
           node.style.fontFamily = `'${serif}'`;
           node.style.fontWeight = serifWeight !== "Default" ? serifWeight : "";
+          node.style.fontSize =
+            serifSize !== "Default" ? `${serifSize}px` : "";
           applied = true;
         } else if (!applied && monospaceTriggers.includes(font) && monospace != "Default") {
           node.style.fontFamily = `'${monospace}'`;
-          node.style.fontWeight = monospaceWeight !== "Default" ? monospaceWeight : "";
+          node.style.fontWeight =
+            monospaceWeight !== "Default" ? monospaceWeight : "";
+          node.style.fontSize =
+            monospaceSize !== "Default" ? `${monospaceSize}px` : "";
           applied = true;
         }
       }
@@ -80,6 +102,9 @@ const changeFontFamily = (
       serifWeight,
       sansSerifWeight,
       monospaceWeight,
+      serifSize,
+      sansSerifSize,
+      monospaceSize,
     );
   }
 };
@@ -98,6 +123,9 @@ browser.runtime.sendMessage(message, undefined, (response) => {
     const serif_weight = response.data.serif_weight || "Default";
     const sans_serif_weight = response.data.sans_serif_weight || "Default";
     const monospace_weight = response.data.monospace_weight || "Default";
+    const serif_size = response.data.serif_size || "Default";
+    const sans_serif_size = response.data.sans_serif_size || "Default";
+    const monospace_size = response.data.monospace_size || "Default";
     changeFontFamily(
       document.body,
       serif,
@@ -106,6 +134,9 @@ browser.runtime.sendMessage(message, undefined, (response) => {
       serif_weight,
       sans_serif_weight,
       monospace_weight,
+      serif_size,
+      sans_serif_size,
+      monospace_size,
     );
   } else if (response.type === "none") {
     console.log("Font not set for site");
@@ -123,6 +154,9 @@ browser.runtime.onConnect.addListener((port) => {
         const serif_weight = message.data.serif_weight || "Default";
         const sans_serif_weight = message.data.sans_serif_weight || "Default";
         const monospace_weight = message.data.monospace_weight || "Default";
+        const serif_size = message.data.serif_size || "Default";
+        const sans_serif_size = message.data.sans_serif_size || "Default";
+        const monospace_size = message.data.monospace_size || "Default";
         changeFontFamily(
           document.body,
           serif,
@@ -131,6 +165,9 @@ browser.runtime.onConnect.addListener((port) => {
           serif_weight,
           sans_serif_weight,
           monospace_weight,
+          serif_size,
+          sans_serif_size,
+          monospace_size,
         );
       } else if (message.type === "restore") {
         location.reload();

--- a/js/popup.js
+++ b/js/popup.js
@@ -65,6 +65,12 @@ const globalSansSerifWeightSelect =
   globalFontSelectionForm.elements["global_sans_serif_weight"];
 const globalMonospaceWeightSelect =
   globalFontSelectionForm.elements["global_monospace_weight"];
+const globalSerifSizeInput =
+  globalFontSelectionForm.elements["global_serif_size"];
+const globalSansSerifSizeInput =
+  globalFontSelectionForm.elements["global_sans_serif_size"];
+const globalMonospaceSizeInput =
+  globalFontSelectionForm.elements["global_monospace_size"];
 const globalSerifPlaceholder = document.querySelector(
   "#global_serif_placeholder"
 );
@@ -133,6 +139,12 @@ browser.storage.sync.get(["global"]).then((result) =>
           global_fonts.sans_serif_weight || "Default";
         globalMonospaceWeightPlaceholder.textContent =
           global_fonts.monospace_weight || "Default";
+        globalSerifSizeInput.placeholder =
+          global_fonts.serif_size || "Default";
+        globalSansSerifSizeInput.placeholder =
+          global_fonts.sans_serif_size || "Default";
+        globalMonospaceSizeInput.placeholder =
+          global_fonts.monospace_size || "Default";
         // Placeholder value
         globalSerifPlaceholder.value =
           global_fonts.serif === "Default" ? "" : global_fonts.serif;
@@ -154,6 +166,20 @@ browser.storage.sync.get(["global"]).then((result) =>
           global_fonts.monospace_weight === "Default"
             ? ""
             : global_fonts.monospace_weight;
+        globalSerifSizeInput.value =
+          global_fonts.serif_size && global_fonts.serif_size !== "Default"
+            ? global_fonts.serif_size
+            : "";
+        globalSansSerifSizeInput.value =
+          global_fonts.sans_serif_size &&
+          global_fonts.sans_serif_size !== "Default"
+            ? global_fonts.sans_serif_size
+            : "";
+        globalMonospaceSizeInput.value =
+          global_fonts.monospace_size &&
+          global_fonts.monospace_size !== "Default"
+            ? global_fonts.monospace_size
+            : "";
       }
       browser.storage.sync.get(["override"]).then((result) => {
         const willOverride = "override" in result && result["override"];
@@ -221,6 +247,12 @@ settingsButton.addEventListener("click", () =>
                 global_fonts.sans_serif_weight || "Default";
               globalMonospaceWeightPlaceholder.textContent =
                 global_fonts.monospace_weight || "Default";
+              globalSerifSizeInput.placeholder =
+                global_fonts.serif_size || "Default";
+              globalSansSerifSizeInput.placeholder =
+                global_fonts.sans_serif_size || "Default";
+              globalMonospaceSizeInput.placeholder =
+                global_fonts.monospace_size || "Default";
               // Placeholder value
               globalSerifPlaceholder.value =
                 global_fonts.serif === "Default" ? "" : global_fonts.serif;
@@ -247,6 +279,21 @@ settingsButton.addEventListener("click", () =>
                 global_fonts.monospace_weight === "Default"
                   ? ""
                   : global_fonts.monospace_weight;
+              globalSerifSizeInput.value =
+                global_fonts.serif_size &&
+                global_fonts.serif_size !== "Default"
+                  ? global_fonts.serif_size
+                  : "";
+              globalSansSerifSizeInput.value =
+                global_fonts.sans_serif_size &&
+                global_fonts.sans_serif_size !== "Default"
+                  ? global_fonts.sans_serif_size
+                  : "";
+              globalMonospaceSizeInput.value =
+                global_fonts.monospace_size &&
+                global_fonts.monospace_size !== "Default"
+                  ? global_fonts.monospace_size
+                  : "";
             }
           } else {
             showTip(tipText);
@@ -314,6 +361,9 @@ const monospaceSelect = fontSelectionForm.elements["monospace"];
 const serifWeightSelect = fontSelectionForm.elements["serif_weight"];
 const sansSerifWeightSelect = fontSelectionForm.elements["sans_serif_weight"];
 const monospaceWeightSelect = fontSelectionForm.elements["monospace_weight"];
+const serifSizeInput = fontSelectionForm.elements["serif_size"];
+const sansSerifSizeInput = fontSelectionForm.elements["sans_serif_size"];
+const monospaceSizeInput = fontSelectionForm.elements["monospace_size"];
 const serifPlaceholder = document.querySelector("#serif_placeholder");
 const sansSerifPlaceholder = document.querySelector("#sans_serif_placeholder");
 const monospacePlaceholder = document.querySelector("#monospace_placeholder");
@@ -338,6 +388,9 @@ const updatePlaceholders = (innerText) => {
     innerText.sans_serif_weight || "Default";
   monospaceWeightPlaceholder.textContent =
     innerText.monospace_weight || "Default";
+  serifSizeInput.placeholder = innerText.serif_size || "Default";
+  sansSerifSizeInput.placeholder = innerText.sans_serif_size || "Default";
+  monospaceSizeInput.placeholder = innerText.monospace_size || "Default";
   // Placeholder value
   serifPlaceholder.value = innerText.serif === "Default" ? "" : innerText.serif;
   sansSerifPlaceholder.value =
@@ -356,6 +409,18 @@ const updatePlaceholders = (innerText) => {
     !innerText.monospace_weight || innerText.monospace_weight === "Default"
       ? ""
       : innerText.monospace_weight;
+  serifSizeInput.value =
+    innerText.serif_size && innerText.serif_size !== "Default"
+      ? innerText.serif_size
+      : "";
+  sansSerifSizeInput.value =
+    innerText.sans_serif_size && innerText.sans_serif_size !== "Default"
+      ? innerText.sans_serif_size
+      : "";
+  monospaceSizeInput.value =
+    innerText.monospace_size && innerText.monospace_size !== "Default"
+      ? innerText.monospace_size
+      : "";
 };
 getDomain().then((domain) => {
   browser.storage.sync.get([domain]).then((result) => {
@@ -475,13 +540,19 @@ fontSelectionForm.addEventListener("submit", (e) => {
   const serifWeightValue = serifWeightSelect.value;
   const sansSerifWeightValue = sansSerifWeightSelect.value;
   const monospaceWeightValue = monospaceWeightSelect.value;
+  const serifSizeValue = serifSizeInput.value;
+  const sansSerifSizeValue = sansSerifSizeInput.value;
+  const monospaceSizeValue = monospaceSizeInput.value;
   if (
     !serifValue.length &&
     !sansSerifValue.length &&
     !monospaceValue.length &&
     !serifWeightValue.length &&
     !sansSerifWeightValue.length &&
-    !monospaceWeightValue.length
+    !monospaceWeightValue.length &&
+    !serifSizeValue.length &&
+    !sansSerifSizeValue.length &&
+    !monospaceSizeValue.length
   )
     applyButton.textContent = "No Changes Made";
   else {
@@ -509,6 +580,13 @@ fontSelectionForm.addEventListener("submit", (e) => {
           monospace_weight: monospaceWeightValue.length
             ? monospaceWeightValue
             : "Default",
+          serif_size: serifSizeValue.length ? serifSizeValue : "Default",
+          sans_serif_size: sansSerifSizeValue.length
+            ? sansSerifSizeValue
+            : "Default",
+          monospace_size: monospaceSizeValue.length
+            ? monospaceSizeValue
+            : "Default",
         };
         browser.tabs.connect(tabs[0].id).postMessage({
           type: "apply_font",
@@ -522,7 +600,10 @@ fontSelectionForm.addEventListener("submit", (e) => {
           monospaceValue.length ||
           serifWeightValue.length ||
           sansSerifWeightValue.length ||
-          monospaceWeightValue.length
+          monospaceWeightValue.length ||
+          serifSizeValue.length ||
+          sansSerifSizeValue.length ||
+          monospaceSizeValue.length
         ) {
           yield browser.storage.sync.set({
             [domain]: fontData,
@@ -561,6 +642,9 @@ globalFontSelectionForm.addEventListener("submit", (e) =>
     const globalSerifWeightValue = globalSerifWeightSelect.value;
     const globalSansSerifWeightValue = globalSansSerifWeightSelect.value;
     const globalMonospaceWeightValue = globalMonospaceWeightSelect.value;
+    const globalSerifSizeValue = globalSerifSizeInput.value;
+    const globalSansSerifSizeValue = globalSansSerifSizeInput.value;
+    const globalMonospaceSizeValue = globalMonospaceSizeInput.value;
     const applyButton = document.getElementById("global-apply-btn");
     if (
       !globalSerifValue.length &&
@@ -568,7 +652,10 @@ globalFontSelectionForm.addEventListener("submit", (e) =>
       !globaMonospaceValue.length &&
       !globalSerifWeightValue.length &&
       !globalSansSerifWeightValue.length &&
-      !globalMonospaceWeightValue.length
+      !globalMonospaceWeightValue.length &&
+      !globalSerifSizeValue.length &&
+      !globalSansSerifSizeValue.length &&
+      !globalMonospaceSizeValue.length
     )
       applyButton.textContent = "No Changes Made";
     else {
@@ -594,6 +681,15 @@ globalFontSelectionForm.addEventListener("submit", (e) =>
           : "Default",
         monospace_weight: globalMonospaceWeightValue.length
           ? globalMonospaceWeightValue
+          : "Default",
+        serif_size: globalSerifSizeValue.length
+          ? globalSerifSizeValue
+          : "Default",
+        sans_serif_size: globalSansSerifSizeValue.length
+          ? globalSansSerifSizeValue
+          : "Default",
+        monospace_size: globalMonospaceSizeValue.length
+          ? globalMonospaceSizeValue
           : "Default",
       },
     });
@@ -627,6 +723,9 @@ restoreButton.addEventListener("click", () =>
       serif_weight: "Default",
       sans_serif_weight: "Default",
       monospace_weight: "Default",
+      serif_size: "Default",
+      sans_serif_size: "Default",
+      monospace_size: "Default",
     });
     document.getElementById("restore_modal").showModal();
     browser.storage.sync.remove(yield getDomain());

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -52,7 +52,7 @@
             <!-- Font Selection -->
             <div>
                 <form name="fonts">
-                    <div class="grid grid-cols-3 gap-4">
+                    <div class="grid grid-cols-4 gap-4">
                         <label class="text-6xl font-serif" for="serif">Serif</label>
                         <select class="text-6xl" id="serif" name="serif">
                             <option id="serif_placeholder" value="">Default</option>
@@ -60,6 +60,7 @@
                         <select class="text-6xl" id="serif_weight" name="serif_weight">
                             <option id="serif_weight_placeholder" value="">Default</option>
                         </select>
+                        <input class="text-6xl" id="serif_size" name="serif_size" type="number" placeholder="Default" />
                         <label class="text-6xl font-sans" for="sans_serif">Sans-serif</label>
                         <select class="text-6xl" id="sans_serif" name="sans_serif">
                             <option id="sans_serif_placeholder" value="">Default</option>
@@ -67,6 +68,7 @@
                         <select class="text-6xl" id="sans_serif_weight" name="sans_serif_weight">
                             <option id="sans_serif_weight_placeholder" value="">Default</option>
                         </select>
+                        <input class="text-6xl" id="sans_serif_size" name="sans_serif_size" type="number" placeholder="Default" />
                         <label class="text-6xl font-mono" for="monospace">Monospace</label>
                         <select class="text-6xl" id="monospace" name="monospace">
                             <option id="monospace_placeholder" value="">Default</option>
@@ -74,6 +76,7 @@
                         <select class="text-6xl" id="monospace_weight" name="monospace_weight">
                             <option id="monospace_weight_placeholder" value="">Default</option>
                         </select>
+                        <input class="text-6xl" id="monospace_size" name="monospace_size" type="number" placeholder="Default" />
                     </div>
                     <br><br><br>
                     <div id="form-btns" class="flex w-full gap-2">
@@ -117,14 +120,15 @@
             </div>
             <div id="global_fonts_selection">
                 <form name="global_fonts">
-                    <div class="grid grid-cols-3 gap-4 text-6xl">
-                        <label class=font-serif" for="serif">Serif</label>
+                    <div class="grid grid-cols-4 gap-4 text-6xl">
+                        <label class="font-serif" for="serif">Serif</label>
                         <select class="" id="global_serif" name="serif">
                             <option id="global_serif_placeholder" value="">Default</option>
                         </select>
                         <select id="global_serif_weight" name="global_serif_weight">
                             <option id="global_serif_weight_placeholder" value="">Default</option>
                         </select>
+                        <input id="global_serif_size" name="global_serif_size" type="number" placeholder="Default" />
                         <label class=" font-sans" for="sans_serif">Sans-serif</label>
                         <select id="global_sans_serif" name="sans_serif">
                             <option id="global_sans_serif_placeholder" value="">Default</option>
@@ -132,6 +136,7 @@
                         <select id="global_sans_serif_weight" name="global_sans_serif_weight">
                             <option id="global_sans_serif_weight_placeholder" value="">Default</option>
                         </select>
+                        <input id="global_sans_serif_size" name="global_sans_serif_size" type="number" placeholder="Default" />
                         <label class=" font-mono" for="monospace">Monospace</label>
                         <select id="global_monospace" name="monospace">
                             <option id="global_monospace_placeholder" value="">Default</option>
@@ -139,6 +144,7 @@
                         <select id="global_monospace_weight" name="global_monospace_weight">
                             <option id="global_monospace_weight_placeholder" value="">Default</option>
                         </select>
+                        <input id="global_monospace_size" name="global_monospace_size" type="number" placeholder="Default" />
                     </div>
                     <br>
                     <div id="global-form-btns" class="flex w-full gap-2 tooltip"


### PR DESCRIPTION
## Summary
- add skip-list targeting to avoid non-content elements
- allow custom font sizes for serif, sans-serif, and monospace fonts

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68980046459883259600e13427bc5979