### PR TITLE
Add preset font sizes and enforce applied size

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -7,10 +7,10 @@ const currentDomain = window.location.hostname;
 const SKIP_SELECTOR =
   'i,[class*="icon"],[class*="fa-"],svg,code,pre,kbd,samp,h1,h2,h3,h4,h5,h6,button';
 function shouldSkip(el) {
-  if (el.closest('.app-banner')) return true;
-  if (el.closest('.byline-wrapper')) return true;
-  if (el.closest('.byline')) return true;
-  if (el.closest('.titleContainer-DJYq5v')) return true;
+  if (el.closest(".app-banner")) return true;
+  if (el.closest(".byline-wrapper")) return true;
+  if (el.closest(".byline")) return true;
+  if (el.closest(".titleContainer-DJYq5v")) return true;
   return el.matches(SKIP_SELECTOR);
 }
 
@@ -44,7 +44,7 @@ const changeFontFamily = (
       // Split into array for order-sensitive matching
       const fontList = fontFamilyLower
         .split(",")
-        .map(f => f.trim().replace(/^["']|["']$/g, "")); // Remove leading/trailing quotes
+        .map((f) => f.trim().replace(/^["']|["']$/g, "")); // Remove leading/trailing quotes
 
       // Define triggers for each type
       const sansSerifTriggers = [
@@ -53,19 +53,10 @@ const changeFontFamily = (
         "helvetica",
         "open sans",
         "open sans-fallback",
-        "verdana"
+        "verdana",
       ];
-      const serifTriggers = [
-        "serif",
-        "georgia",
-        "times",
-        "times new roman"
-      ];
-      const monospaceTriggers = [
-        "monospace",
-        "courier",
-        "courier new"
-      ];
+      const serifTriggers = ["serif", "georgia", "times", "times new roman"];
+      const monospaceTriggers = ["monospace", "courier", "courier new"];
 
       let fontType = null;
       for (const font of fontList) {
@@ -89,7 +80,11 @@ const changeFontFamily = (
           node.style.fontWeight = sansSerifWeight;
         }
         if (sansSerifSize !== "Default" && sansSerifSize) {
-          node.style.fontSize = `${sansSerifSize}px`;
+          node.style.setProperty(
+            "font-size",
+            `${sansSerifSize}px`,
+            "important",
+          );
         }
       } else if (fontType === "serif") {
         if (serif !== "Default") {
@@ -99,7 +94,7 @@ const changeFontFamily = (
           node.style.fontWeight = serifWeight;
         }
         if (serifSize !== "Default" && serifSize) {
-          node.style.fontSize = `${serifSize}px`;
+          node.style.setProperty("font-size", `${serifSize}px`, "important");
         }
       } else if (fontType === "monospace") {
         if (monospace !== "Default") {
@@ -109,7 +104,11 @@ const changeFontFamily = (
           node.style.fontWeight = monospaceWeight;
         }
         if (monospaceSize !== "Default" && monospaceSize) {
-          node.style.fontSize = `${monospaceSize}px`;
+          node.style.setProperty(
+            "font-size",
+            `${monospaceSize}px`,
+            "important",
+          );
         }
       }
     }

--- a/js/popup.js
+++ b/js/popup.js
@@ -50,7 +50,7 @@ const tipWhenOverrideOff = document.getElementById("tip-override-off");
 const tipWhenSiteIsExempted = document.getElementById("tip-exempt");
 const tipBox = document.getElementById("tip-box");
 const globalNotSelectedInfoText = document.getElementById(
-  "global_not_checked_info_text"
+  "global_not_checked_info_text",
 );
 const globalFontsSelection = document.getElementById("global_fonts_selection");
 const globalFontSelectionForm = document.forms["global_fonts"];
@@ -72,22 +72,22 @@ const globalSansSerifSizeInput =
 const globalMonospaceSizeInput =
   globalFontSelectionForm.elements["global_monospace_size"];
 const globalSerifPlaceholder = document.querySelector(
-  "#global_serif_placeholder"
+  "#global_serif_placeholder",
 );
 const globalSansSerifPlaceholder = document.querySelector(
-  "#global_sans_serif_placeholder"
+  "#global_sans_serif_placeholder",
 );
 const globalMonospacePlaceholder = document.querySelector(
-  "#global_monospace_placeholder"
+  "#global_monospace_placeholder",
 );
 const globalSerifWeightPlaceholder = document.querySelector(
-  "#global_serif_weight_placeholder"
+  "#global_serif_weight_placeholder",
 );
 const globalSansSerifWeightPlaceholder = document.querySelector(
-  "#global_sans_serif_weight_placeholder"
+  "#global_sans_serif_weight_placeholder",
 );
 const globalMonospaceWeightPlaceholder = document.querySelector(
-  "#global_monospace_weight_placeholder"
+  "#global_monospace_weight_placeholder",
 );
 tipWhenOverrideOn.remove();
 tipWhenOverrideOff.remove();
@@ -107,7 +107,7 @@ const getDomain = () => {
       (tabs) => {
         if (tabs[0] && tabs[0].url) resolve(new URL(tabs[0].url).hostname);
         else reject(new Error("Could not return tab url"));
-      }
+      },
     );
   });
 };
@@ -139,12 +139,6 @@ browser.storage.sync.get(["global"]).then((result) =>
           global_fonts.sans_serif_weight || "Default";
         globalMonospaceWeightPlaceholder.textContent =
           global_fonts.monospace_weight || "Default";
-        globalSerifSizeInput.placeholder =
-          global_fonts.serif_size || "Default";
-        globalSansSerifSizeInput.placeholder =
-          global_fonts.sans_serif_size || "Default";
-        globalMonospaceSizeInput.placeholder =
-          global_fonts.monospace_size || "Default";
         // Placeholder value
         globalSerifPlaceholder.value =
           global_fonts.serif === "Default" ? "" : global_fonts.serif;
@@ -192,12 +186,12 @@ browser.storage.sync.get(["global"]).then((result) =>
             "exempts" in result &&
             result["exempts"].includes(yield getDomain()) &&
             showTip(tipWhenSiteIsExempted);
-        })
+        }),
       );
     } else {
       globalFontsSelection.remove();
     }
-  })
+  }),
 );
 settingsButton.addEventListener("click", () =>
   __awaiter(this, void 0, void 0, function* () {
@@ -219,7 +213,7 @@ settingsButton.addEventListener("click", () =>
           });
           if (globalCheck.checked) {
             showTip(
-              overrideCheck.checked ? tipWhenOverrideOn : tipWhenOverrideOff
+              overrideCheck.checked ? tipWhenOverrideOn : tipWhenOverrideOff,
             );
             exemptCheck.checked && showTip(tipWhenSiteIsExempted);
             globalNotSelectedInfoText.remove();
@@ -247,12 +241,6 @@ settingsButton.addEventListener("click", () =>
                 global_fonts.sans_serif_weight || "Default";
               globalMonospaceWeightPlaceholder.textContent =
                 global_fonts.monospace_weight || "Default";
-              globalSerifSizeInput.placeholder =
-                global_fonts.serif_size || "Default";
-              globalSansSerifSizeInput.placeholder =
-                global_fonts.sans_serif_size || "Default";
-              globalMonospaceSizeInput.placeholder =
-                global_fonts.monospace_size || "Default";
               // Placeholder value
               globalSerifPlaceholder.value =
                 global_fonts.serif === "Default" ? "" : global_fonts.serif;
@@ -280,8 +268,7 @@ settingsButton.addEventListener("click", () =>
                   ? ""
                   : global_fonts.monospace_weight;
               globalSerifSizeInput.value =
-                global_fonts.serif_size &&
-                global_fonts.serif_size !== "Default"
+                global_fonts.serif_size && global_fonts.serif_size !== "Default"
                   ? global_fonts.serif_size
                   : "";
               globalSansSerifSizeInput.value =
@@ -300,7 +287,7 @@ settingsButton.addEventListener("click", () =>
             globalFontsSelection.remove();
             settingsPage.appendChild(globalNotSelectedInfoText);
           }
-        })
+        }),
       );
       overrideCheck.addEventListener("change", () =>
         __awaiter(this, void 0, void 0, function* () {
@@ -308,9 +295,9 @@ settingsButton.addEventListener("click", () =>
             override: overrideCheck.checked,
           });
           showTip(
-            overrideCheck.checked ? tipWhenOverrideOn : tipWhenOverrideOff
+            overrideCheck.checked ? tipWhenOverrideOn : tipWhenOverrideOff,
           );
-        })
+        }),
       );
       exemptCheck.addEventListener("change", () =>
         __awaiter(this, void 0, void 0, function* () {
@@ -324,20 +311,20 @@ settingsButton.addEventListener("click", () =>
           else {
             exempted_domains = exempted_domains.filter((el) => el !== domain);
             showTip(
-              overrideCheck.checked ? tipWhenOverrideOn : tipWhenOverrideOff
+              overrideCheck.checked ? tipWhenOverrideOn : tipWhenOverrideOff,
             );
           }
           yield browser.storage.sync.set({
             exempts: exempted_domains,
           });
-        })
+        }),
       );
     } else {
       settingsButton.textContent = "Settings";
       settingsPage.remove();
       wrapper.appendChild(homePage);
     }
-  })
+  }),
 );
 supportButton.addEventListener("click", () => {
   if (supportButton.textContent.includes("Supp")) {
@@ -368,13 +355,13 @@ const serifPlaceholder = document.querySelector("#serif_placeholder");
 const sansSerifPlaceholder = document.querySelector("#sans_serif_placeholder");
 const monospacePlaceholder = document.querySelector("#monospace_placeholder");
 const serifWeightPlaceholder = document.querySelector(
-  "#serif_weight_placeholder"
+  "#serif_weight_placeholder",
 );
 const sansSerifWeightPlaceholder = document.querySelector(
-  "#sans_serif_weight_placeholder"
+  "#sans_serif_weight_placeholder",
 );
 const monospaceWeightPlaceholder = document.querySelector(
-  "#monospace_weight_placeholder"
+  "#monospace_weight_placeholder",
 );
 // Populating placeholder values + checkbox
 const updatePlaceholders = (innerText) => {
@@ -382,15 +369,11 @@ const updatePlaceholders = (innerText) => {
   serifPlaceholder.textContent = innerText.serif;
   sansSerifPlaceholder.textContent = innerText.sans_serif;
   monospacePlaceholder.textContent = innerText.monospace;
-  serifWeightPlaceholder.textContent =
-    innerText.serif_weight || "Default";
+  serifWeightPlaceholder.textContent = innerText.serif_weight || "Default";
   sansSerifWeightPlaceholder.textContent =
     innerText.sans_serif_weight || "Default";
   monospaceWeightPlaceholder.textContent =
     innerText.monospace_weight || "Default";
-  serifSizeInput.placeholder = innerText.serif_size || "Default";
-  sansSerifSizeInput.placeholder = innerText.sans_serif_size || "Default";
-  monospaceSizeInput.placeholder = innerText.monospace_size || "Default";
   // Placeholder value
   serifPlaceholder.value = innerText.serif === "Default" ? "" : innerText.serif;
   sansSerifPlaceholder.value =
@@ -569,9 +552,7 @@ fontSelectionForm.addEventListener("submit", (e) => {
         // telling the service worker to apply the font
         const fontData = {
           serif: serifValue.length ? serifValue : "Default",
-          serif_weight: serifWeightValue.length
-            ? serifWeightValue
-            : "Default",
+          serif_weight: serifWeightValue.length ? serifWeightValue : "Default",
           sans_serif: sansSerifValue.length ? sansSerifValue : "Default",
           sans_serif_weight: sansSerifWeightValue.length
             ? sansSerifWeightValue
@@ -617,7 +598,7 @@ fontSelectionForm.addEventListener("submit", (e) => {
           exempts_list["exempts"].includes(domain)
         ) {
           console.log(
-            "This site has been exempted, so don't change the global fonts"
+            "This site has been exempted, so don't change the global fonts",
           );
         } else {
           const result = yield browser.storage.sync.get(["global"]);
@@ -626,7 +607,7 @@ fontSelectionForm.addEventListener("submit", (e) => {
               global_fonts: fontData,
             });
         }
-      })
+      }),
     );
   } catch (e) {
     console.error("Error applying or saving font.");
@@ -676,9 +657,7 @@ globalFontSelectionForm.addEventListener("submit", (e) =>
         sans_serif_weight: globalSansSerifWeightValue.length
           ? globalSansSerifWeightValue
           : "Default",
-        monospace: globaMonospaceValue.length
-          ? globaMonospaceValue
-          : "Default",
+        monospace: globaMonospaceValue.length ? globaMonospaceValue : "Default",
         monospace_weight: globalMonospaceWeightValue.length
           ? globalMonospaceWeightValue
           : "Default",
@@ -693,7 +672,7 @@ globalFontSelectionForm.addEventListener("submit", (e) =>
           : "Default",
       },
     });
-  })
+  }),
 );
 restoreButton.addEventListener("click", () =>
   __awaiter(this, void 0, void 0, function* () {
@@ -730,5 +709,5 @@ restoreButton.addEventListener("click", () =>
     document.getElementById("restore_modal").showModal();
     browser.storage.sync.remove(yield getDomain());
     restoreButton.remove();
-  })
+  }),
 );

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -1,220 +1,411 @@
 <html>
-
-<head>
+  <head>
     <title>Fontonic</title>
-    <meta charset='UTF-8' />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,100..900;1,100..900&display=swap"
-        rel="stylesheet">
-    <link rel="stylesheet" href="popup.css">
+    <meta charset="UTF-8" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,100..900;1,100..900&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="popup.css" />
     <script defer src="../js/popup.js"></script>
-</head>
+  </head>
 
-<body>
+  <body>
     <!-- Wrapper -->
-    <div id="wrapper" style="font-family: 'Inter Tight', sans-serif; padding: 2rem;">
-        <!-- Header -->
-        <div class="flex justify-between items-center">
-            <!-- Logo -->
-            <a href="https://fontonic.amkhrjee.xyz">
-                <div class="flex items-center">
-                    <img src="../res/icons/favicon-96x96.png">
-                    <h2 style="color: #ff914c;" class="text-6xl font-bold items-center">Fontonic</h2>
-                </div>
-            </a>
-            <div class="flex gap-4 items-center">
-                <button id="settings-btn" class="btn btn-ghost text-5xl">Settings</button>
-                <button id="support-btn" class="text-accent font-bold text-5xl">
-                    Support</button>
-            </div>
+    <div
+      id="wrapper"
+      style="font-family: &quot;Inter Tight&quot;, sans-serif; padding: 2rem"
+    >
+      <!-- Header -->
+      <div class="flex justify-between items-center">
+        <!-- Logo -->
+        <a href="https://fontonic.amkhrjee.xyz">
+          <div class="flex items-center">
+            <img src="../res/icons/favicon-96x96.png" />
+            <h2 style="color: #ff914c" class="text-6xl font-bold items-center">
+              Fontonic
+            </h2>
+          </div>
+        </a>
+        <div class="flex gap-4 items-center">
+          <button id="settings-btn" class="btn btn-ghost text-5xl">
+            Settings
+          </button>
+          <button id="support-btn" class="text-accent font-bold text-5xl">
+            Support
+          </button>
         </div>
-        <br>
-        <div id="home-page">
-            <!-- Information -->
-            <div class="text-5xl">
-                <br>
-                <p>You can <a class="link link-primary" href=" https://forms.gle/3eqT9NU3mGHNjtyD8">report↗</a>
-                    unsupported websites.</p>
-                <br>
-                <div id="tip-box">
-                    <p id="tip">↺ Refresh if you don't see any changes.</p>
-                    <p id="tip-override-off" class="text-warning">✺ Global fonts apply is on. Override is off.
-                    </p>
-                    <p id="tip-override-on" class="text-warning">✺ Global fonts apply is on. Override is on.
-                    </p>
-                    <p id="tip-exempt" class="text-warning">⮾ This site is exempted from the global settings.</p>
-                </div>
-            </div>
-            <br>
-            <br><br>
-
-            <!-- Font Selection -->
-            <div>
-                <form name="fonts">
-                    <div class="grid grid-cols-4 gap-4">
-                        <label class="text-6xl font-serif" for="serif">Serif</label>
-                        <select class="text-6xl" id="serif" name="serif">
-                            <option id="serif_placeholder" value="">Default</option>
-                        </select>
-                        <select class="text-6xl" id="serif_weight" name="serif_weight">
-                            <option id="serif_weight_placeholder" value="">Default</option>
-                        </select>
-                        <input class="text-6xl" id="serif_size" name="serif_size" type="number" placeholder="Default" />
-                        <label class="text-6xl font-sans" for="sans_serif">Sans-serif</label>
-                        <select class="text-6xl" id="sans_serif" name="sans_serif">
-                            <option id="sans_serif_placeholder" value="">Default</option>
-                        </select>
-                        <select class="text-6xl" id="sans_serif_weight" name="sans_serif_weight">
-                            <option id="sans_serif_weight_placeholder" value="">Default</option>
-                        </select>
-                        <input class="text-6xl" id="sans_serif_size" name="sans_serif_size" type="number" placeholder="Default" />
-                        <label class="text-6xl font-mono" for="monospace">Monospace</label>
-                        <select class="text-6xl" id="monospace" name="monospace">
-                            <option id="monospace_placeholder" value="">Default</option>
-                        </select>
-                        <select class="text-6xl" id="monospace_weight" name="monospace_weight">
-                            <option id="monospace_weight_placeholder" value="">Default</option>
-                        </select>
-                        <input class="text-6xl" id="monospace_size" name="monospace_size" type="number" placeholder="Default" />
-                    </div>
-                    <br><br><br>
-                    <div id="form-btns" class="flex w-full gap-2">
-                        <button style="height: 7rem;" id="restore-btn" type="button"
-                            class="btn btn-accent flex-1 text-5xl">↺ Restore</button>
-                        <button style="height: 7rem;" id="apply-btn" type="submit"
-                            class="btn btn-primary flex-1 text-5xl">Apply
-                            Selection</button>
-
-                    </div>
-                </form>
-            </div>
+      </div>
+      <br />
+      <div id="home-page">
+        <!-- Information -->
+        <div class="text-5xl">
+          <br />
+          <p>
+            You can
+            <a
+              class="link link-primary"
+              href=" https://forms.gle/3eqT9NU3mGHNjtyD8"
+              >report↗</a
+            >
+            unsupported websites.
+          </p>
+          <br />
+          <div id="tip-box">
+            <p id="tip">↺ Refresh if you don't see any changes.</p>
+            <p id="tip-override-off" class="text-warning">
+              ✺ Global fonts apply is on. Override is off.
+            </p>
+            <p id="tip-override-on" class="text-warning">
+              ✺ Global fonts apply is on. Override is on.
+            </p>
+            <p id="tip-exempt" class="text-warning">
+              ⮾ This site is exempted from the global settings.
+            </p>
+          </div>
         </div>
+        <br />
+        <br /><br />
 
-        <!-- Settings page -->
-        <div id="settings-page">
-            <br>
-            <br>
-
-            <div class="flex justify-between items-center text-5xl">
-                <p>Apply selections to all sites</p>
-                <input style="scale: 2;" id="global_check" type="checkbox" class="toggle toggle-primary" />
+        <!-- Font Selection -->
+        <div>
+          <form name="fonts">
+            <div class="grid grid-cols-4 gap-4">
+              <label class="text-6xl font-serif" for="serif">Serif</label>
+              <select class="text-6xl" id="serif" name="serif">
+                <option id="serif_placeholder" value="">Default</option>
+              </select>
+              <select class="text-6xl" id="serif_weight" name="serif_weight">
+                <option id="serif_weight_placeholder" value="">Default</option>
+              </select>
+              <select class="text-6xl" id="serif_size" name="serif_size">
+                <option value="">Default</option>
+                <option value="16">16</option>
+                <option value="17">17</option>
+                <option value="18">18</option>
+                <option value="19">19</option>
+                <option value="20">20</option>
+              </select>
+              <label class="text-6xl font-sans" for="sans_serif"
+                >Sans-serif</label
+              >
+              <select class="text-6xl" id="sans_serif" name="sans_serif">
+                <option id="sans_serif_placeholder" value="">Default</option>
+              </select>
+              <select
+                class="text-6xl"
+                id="sans_serif_weight"
+                name="sans_serif_weight"
+              >
+                <option id="sans_serif_weight_placeholder" value="">
+                  Default
+                </option>
+              </select>
+              <select
+                class="text-6xl"
+                id="sans_serif_size"
+                name="sans_serif_size"
+              >
+                <option value="">Default</option>
+                <option value="16">16</option>
+                <option value="17">17</option>
+                <option value="18">18</option>
+                <option value="19">19</option>
+                <option value="20">20</option>
+              </select>
+              <label class="text-6xl font-mono" for="monospace"
+                >Monospace</label
+              >
+              <select class="text-6xl" id="monospace" name="monospace">
+                <option id="monospace_placeholder" value="">Default</option>
+              </select>
+              <select
+                class="text-6xl"
+                id="monospace_weight"
+                name="monospace_weight"
+              >
+                <option id="monospace_weight_placeholder" value="">
+                  Default
+                </option>
+              </select>
+              <select
+                class="text-6xl"
+                id="monospace_size"
+                name="monospace_size"
+              >
+                <option value="">Default</option>
+                <option value="16">16</option>
+                <option value="17">17</option>
+                <option value="18">18</option>
+                <option value="19">19</option>
+                <option value="20">20</option>
+              </select>
             </div>
-            <br><br><br>
-            <div class="flex justify-between items-center text-5xl">
-                <p>Override existing selections</p>
-                <input style="scale: 2;" id="override_check" type="checkbox" disabled class="toggle toggle-primary" />
+            <br /><br /><br />
+            <div id="form-btns" class="flex w-full gap-2">
+              <button
+                style="height: 7rem"
+                id="restore-btn"
+                type="button"
+                class="btn btn-accent flex-1 text-5xl"
+              >
+                ↺ Restore
+              </button>
+              <button
+                style="height: 7rem"
+                id="apply-btn"
+                type="submit"
+                class="btn btn-primary flex-1 text-5xl"
+              >
+                Apply Selection
+              </button>
             </div>
-            <br>
-            <br><br>
-            <div class="flex justify-between items-center text-5xl">
-                <p>Exempt current site from global settings</p>
-                <input style="scale: 2;" id="exempt_check" type="checkbox" disabled class="toggle toggle-primary" />
-            </div>
-            <br><br>
-
-            <div class="divider"></div>
-            <div id="global_not_checked_info_text"
-                class="text-5xl border border-dashed rounded-md border-primary p-24 text-center flex justify-center items-center">
-                <p>To apply fonts to all websites, select fonts for any website and turn on the setting.</p>
-            </div>
-            <div id="global_fonts_selection">
-                <form name="global_fonts">
-                    <div class="grid grid-cols-4 gap-4 text-6xl">
-                        <label class="font-serif" for="serif">Serif</label>
-                        <select class="" id="global_serif" name="serif">
-                            <option id="global_serif_placeholder" value="">Default</option>
-                        </select>
-                        <select id="global_serif_weight" name="global_serif_weight">
-                            <option id="global_serif_weight_placeholder" value="">Default</option>
-                        </select>
-                        <input id="global_serif_size" name="global_serif_size" type="number" placeholder="Default" />
-                        <label class=" font-sans" for="sans_serif">Sans-serif</label>
-                        <select id="global_sans_serif" name="sans_serif">
-                            <option id="global_sans_serif_placeholder" value="">Default</option>
-                        </select>
-                        <select id="global_sans_serif_weight" name="global_sans_serif_weight">
-                            <option id="global_sans_serif_weight_placeholder" value="">Default</option>
-                        </select>
-                        <input id="global_sans_serif_size" name="global_sans_serif_size" type="number" placeholder="Default" />
-                        <label class=" font-mono" for="monospace">Monospace</label>
-                        <select id="global_monospace" name="monospace">
-                            <option id="global_monospace_placeholder" value="">Default</option>
-                        </select>
-                        <select id="global_monospace_weight" name="global_monospace_weight">
-                            <option id="global_monospace_weight_placeholder" value="">Default</option>
-                        </select>
-                        <input id="global_monospace_size" name="global_monospace_size" type="number" placeholder="Default" />
-                    </div>
-                    <br>
-                    <div id="global-form-btns" class="flex w-full gap-2 tooltip"
-                        data-tip="Modifies your global fonts selection">
-                        <button style="height: 7rem;" id="global-apply-btn" type="submit"
-                            class="btn btn-neutral flex-1 text-5xl">
-                            🌐 Apply to all sites
-                        </button>
-                    </div>
-                </form>
-            </div>
+          </form>
         </div>
+      </div>
 
-        <!-- Support Page -->
-        <div id="support-page">
-            <br><br>
-            <div class="grid grid-cols-2 gap-2">
-                <a style="height: 7rem;" href="https://paypal.me/amkhrjee?country.x=IN&locale.x=en_GB" target="_blank"
-                    class="btn btn-primary text-5xl">Support via PayPal</a>
-                <a style="height: 7rem;" href="https://www.buymeacoffee.com/amkhrjee" target="_blank"
-                    class="btn btn-primary text-5xl">Buy Me A
-                    Coffee</a>
-                <a style="height: 7rem;" href="https://ko-fi.com/amkhrjee" target="_blank"
-                    class="btn btn-primary text-5xl">Support via Ko-Fi</a>
-                <a style="height: 7rem;"
-                    href="https://chromewebstore.google.com/detail/fontonic-change-fonts/hnjlnpipbcbgllcjgbcjfgepmeomdcog"
-                    target="_blank" class="btn btn-primary text-5xl">Leave a rating</a>
-            </div>
-            <br>
-            <br><br>
-            <div class="text-5xl text-center text-accent font-bold">
-                <p>Support this project to keep it ad-free! ❤️</p>
-            </div>
-            <br>
-            <div class="text-4xl text-center p-4 ">
-                <p>
-                    v1.5 • Fontonic for Firefox • April 2025
-                </p>
-                <br>
-                <p>Made by <a class="link link-primary" href="https://amkhrjee.xyz" target="_blank">amkhrjee↗</a> • View
-                    <a class="link link-primary" href="https://github.com/amkhrjee/fontonic" target="_blank">source
-                        code↗</a>
-                </p>
-            </div>
+      <!-- Settings page -->
+      <div id="settings-page">
+        <br />
+        <br />
+
+        <div class="flex justify-between items-center text-5xl">
+          <p>Apply selections to all sites</p>
+          <input
+            style="scale: 2"
+            id="global_check"
+            type="checkbox"
+            class="toggle toggle-primary"
+          />
         </div>
-    </div>
+        <br /><br /><br />
+        <div class="flex justify-between items-center text-5xl">
+          <p>Override existing selections</p>
+          <input
+            style="scale: 2"
+            id="override_check"
+            type="checkbox"
+            disabled
+            class="toggle toggle-primary"
+          />
+        </div>
+        <br />
+        <br /><br />
+        <div class="flex justify-between items-center text-5xl">
+          <p>Exempt current site from global settings</p>
+          <input
+            style="scale: 2"
+            id="exempt_check"
+            type="checkbox"
+            disabled
+            class="toggle toggle-primary"
+          />
+        </div>
+        <br /><br />
+
+        <div class="divider"></div>
+        <div
+          id="global_not_checked_info_text"
+          class="text-5xl border border-dashed rounded-md border-primary p-24 text-center flex justify-center items-center"
+        >
+          <p>
+            To apply fonts to all websites, select fonts for any website and
+            turn on the setting.
+          </p>
+        </div>
+        <div id="global_fonts_selection">
+          <form name="global_fonts">
+            <div class="grid grid-cols-4 gap-4 text-6xl">
+              <label class="font-serif" for="serif">Serif</label>
+              <select class="" id="global_serif" name="serif">
+                <option id="global_serif_placeholder" value="">Default</option>
+              </select>
+              <select id="global_serif_weight" name="global_serif_weight">
+                <option id="global_serif_weight_placeholder" value="">
+                  Default
+                </option>
+              </select>
+              <select id="global_serif_size" name="global_serif_size">
+                <option value="">Default</option>
+                <option value="16">16</option>
+                <option value="17">17</option>
+                <option value="18">18</option>
+                <option value="19">19</option>
+                <option value="20">20</option>
+              </select>
+              <label class="font-sans" for="sans_serif">Sans-serif</label>
+              <select id="global_sans_serif" name="sans_serif">
+                <option id="global_sans_serif_placeholder" value="">
+                  Default
+                </option>
+              </select>
+              <select
+                id="global_sans_serif_weight"
+                name="global_sans_serif_weight"
+              >
+                <option id="global_sans_serif_weight_placeholder" value="">
+                  Default
+                </option>
+              </select>
+              <select id="global_sans_serif_size" name="global_sans_serif_size">
+                <option value="">Default</option>
+                <option value="16">16</option>
+                <option value="17">17</option>
+                <option value="18">18</option>
+                <option value="19">19</option>
+                <option value="20">20</option>
+              </select>
+              <label class="font-mono" for="monospace">Monospace</label>
+              <select id="global_monospace" name="monospace">
+                <option id="global_monospace_placeholder" value="">
+                  Default
+                </option>
+              </select>
+              <select
+                id="global_monospace_weight"
+                name="global_monospace_weight"
+              >
+                <option id="global_monospace_weight_placeholder" value="">
+                  Default
+                </option>
+              </select>
+              <select id="global_monospace_size" name="global_monospace_size">
+                <option value="">Default</option>
+                <option value="16">16</option>
+                <option value="17">17</option>
+                <option value="18">18</option>
+                <option value="19">19</option>
+                <option value="20">20</option>
+              </select>
+            </div>
+            <br />
+            <div
+              id="global-form-btns"
+              class="flex w-full gap-2 tooltip"
+              data-tip="Modifies your global fonts selection"
+            >
+              <button
+                style="height: 7rem"
+                id="global-apply-btn"
+                type="submit"
+                class="btn btn-neutral flex-1 text-5xl"
+              >
+                🌐 Apply to all sites
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <!-- Support Page -->
+      <div id="support-page">
+        <br /><br />
+        <div class="grid grid-cols-2 gap-2">
+          <a
+            style="height: 7rem"
+            href="https://paypal.me/amkhrjee?country.x=IN&locale.x=en_GB"
+            target="_blank"
+            class="btn btn-primary text-5xl"
+            >Support via PayPal</a
+          >
+          <a
+            style="height: 7rem"
+            href="https://www.buymeacoffee.com/amkhrjee"
+            target="_blank"
+            class="btn btn-primary text-5xl"
+            >Buy Me A Coffee</a
+          >
+          <a
+            style="height: 7rem"
+            href="https://ko-fi.com/amkhrjee"
+            target="_blank"
+            class="btn btn-primary text-5xl"
+            >Support via Ko-Fi</a
+          >
+          <a
+            style="height: 7rem"
+            href="https://chromewebstore.google.com/detail/fontonic-change-fonts/hnjlnpipbcbgllcjgbcjfgepmeomdcog"
+            target="_blank"
+            class="btn btn-primary text-5xl"
+            >Leave a rating</a
+          >
+        </div>
+        <br />
+        <br /><br />
+        <div class="text-5xl text-center text-accent font-bold">
+          <p>Support this project to keep it ad-free! ❤️</p>
+        </div>
+        <br />
+        <div class="text-4xl text-center p-4">
+          <p>v1.5 • Fontonic for Firefox • April 2025</p>
+          <br />
+          <p>
+            Made by
+            <a
+              class="link link-primary"
+              href="https://amkhrjee.xyz"
+              target="_blank"
+              >amkhrjee↗</a
+            >
+            • View
+            <a
+              class="link link-primary"
+              href="https://github.com/amkhrjee/fontonic"
+              target="_blank"
+              >source code↗</a
+            >
+          </p>
+        </div>
+      </div>
     </div>
     <dialog id="restore_modal" class="modal font-sans">
-        <div class="modal-box w-full">
-            <h3 style="font-family: 'Inter Tight';" class="text-6xl font-bold">Fonts Restored</h3>
-            <p style="font-family: 'Inter Tight';" class="py-4 text-5xl">Refresh the page to see changes.</p>
-            <div style="font-family: 'Inter Tight';" class="modal-action">
-                <form method="dialog">
-                    <button style="font-family: 'Inter Tight';" class="btn text-5xl">OK</button>
-                </form>
-            </div>
+      <div class="modal-box w-full">
+        <h3
+          style="font-family: &quot;Inter Tight&quot;"
+          class="text-6xl font-bold"
+        >
+          Fonts Restored
+        </h3>
+        <p style="font-family: &quot;Inter Tight&quot;" class="py-4 text-5xl">
+          Refresh the page to see changes.
+        </p>
+        <div style="font-family: &quot;Inter Tight&quot;" class="modal-action">
+          <form method="dialog">
+            <button
+              style="font-family: &quot;Inter Tight&quot;"
+              class="btn text-5xl"
+            >
+              OK
+            </button>
+          </form>
         </div>
+      </div>
     </dialog>
     <dialog id="warning_modal" class="modal font-sans">
-        <div class="modal-box w-3/4">
-            <h3 style="font-family: 'Inter Tight';" class="font-bold text-6xl">Global apply was on</h3>
-            <p style="font-family: 'Inter Tight';" class="py-4 text-6xl">Fonts will restore to default on all websites.
-                You'll have to manually restore for exempted sites. Global apply will be turned off.</p>
-            <div style="font-family: 'Inter Tight';" class="modal-action">
-                <form method="dialog">
-                    <button style="font-family: 'Inter Tight';" class="btn text-5xl">OK</button>
-                </form>
-            </div>
+      <div class="modal-box w-3/4">
+        <h3
+          style="font-family: &quot;Inter Tight&quot;"
+          class="font-bold text-6xl"
+        >
+          Global apply was on
+        </h3>
+        <p style="font-family: &quot;Inter Tight&quot;" class="py-4 text-6xl">
+          Fonts will restore to default on all websites. You'll have to manually
+          restore for exempted sites. Global apply will be turned off.
+        </p>
+        <div style="font-family: &quot;Inter Tight&quot;" class="modal-action">
+          <form method="dialog">
+            <button
+              style="font-family: &quot;Inter Tight&quot;"
+              class="btn text-5xl"
+            >
+              OK
+            </button>
+          </form>
         </div>
+      </div>
     </dialog>
-</body>
-
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace numeric font-size inputs with dropdowns offering 16–20px choices in both site and global settings
- Ensure applied font sizes override page styles by setting them with `!important`
- Update popup logic to work with the new font-size selectors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: web-ext not found)*

------
https://chatgpt.com/codex/tasks/task_e_689815fcab688325a3576469a140e788