### PR TITLE
Organize font selection layout into rows

### DIFF
--- a/popup/popup.html
+++ b/popup/popup.html
@@ -76,76 +76,92 @@
               <!-- Serif -->
               <div class="flex flex-col gap-2">
                 <label class="text-6xl font-serif" for="serif">Serif</label>
-                <select class="text-6xl w-full" id="serif" name="serif">
-                  <option id="serif_placeholder" value="">Default</option>
-                </select>
-                <select class="text-6xl w-full" id="serif_size" name="serif_size">
-                  <option value="">Default</option>
-                  <option value="16">16</option>
-                  <option value="17">17</option>
-                  <option value="18">18</option>
-                  <option value="19">19</option>
-                  <option value="20">20</option>
-                </select>
-                <select class="text-6xl w-full" id="serif_weight" name="serif_weight">
-                  <option id="serif_weight_placeholder" value="">Default</option>
-                </select>
+                <div class="flex gap-2">
+                  <select class="text-6xl flex-1" id="serif" name="serif">
+                    <option id="serif_placeholder" value="">Default</option>
+                  </select>
+                  <select
+                    class="text-6xl flex-1"
+                    id="serif_size"
+                    name="serif_size"
+                  >
+                    <option value="">Default</option>
+                    <option value="16">16</option>
+                    <option value="17">17</option>
+                    <option value="18">18</option>
+                    <option value="19">19</option>
+                    <option value="20">20</option>
+                  </select>
+                  <select
+                    class="text-6xl flex-1"
+                    id="serif_weight"
+                    name="serif_weight"
+                  >
+                    <option id="serif_weight_placeholder" value="">
+                      Default
+                    </option>
+                  </select>
+                </div>
               </div>
               <!-- Sans-serif -->
               <div class="flex flex-col gap-2">
                 <label class="text-6xl font-sans" for="sans_serif">Sans-serif</label>
-                <select class="text-6xl w-full" id="sans_serif" name="sans_serif">
-                  <option id="sans_serif_placeholder" value="">Default</option>
-                </select>
-                <select
-                  class="text-6xl w-full"
-                  id="sans_serif_size"
-                  name="sans_serif_size"
-                >
-                  <option value="">Default</option>
-                  <option value="16">16</option>
-                  <option value="17">17</option>
-                  <option value="18">18</option>
-                  <option value="19">19</option>
-                  <option value="20">20</option>
-                </select>
-                <select
-                  class="text-6xl w-full"
-                  id="sans_serif_weight"
-                  name="sans_serif_weight"
-                >
-                  <option id="sans_serif_weight_placeholder" value="">
-                    Default
-                  </option>
-                </select>
+                <div class="flex gap-2">
+                  <select class="text-6xl flex-1" id="sans_serif" name="sans_serif">
+                    <option id="sans_serif_placeholder" value="">Default</option>
+                  </select>
+                  <select
+                    class="text-6xl flex-1"
+                    id="sans_serif_size"
+                    name="sans_serif_size"
+                  >
+                    <option value="">Default</option>
+                    <option value="16">16</option>
+                    <option value="17">17</option>
+                    <option value="18">18</option>
+                    <option value="19">19</option>
+                    <option value="20">20</option>
+                  </select>
+                  <select
+                    class="text-6xl flex-1"
+                    id="sans_serif_weight"
+                    name="sans_serif_weight"
+                  >
+                    <option id="sans_serif_weight_placeholder" value="">
+                      Default
+                    </option>
+                  </select>
+                </div>
               </div>
               <!-- Monospace -->
               <div class="flex flex-col gap-2">
                 <label class="text-6xl font-mono" for="monospace">Monospace</label>
-                <select class="text-6xl w-full" id="monospace" name="monospace">
-                  <option id="monospace_placeholder" value="">Default</option>
-                </select>
-                <select
-                  class="text-6xl w-full"
-                  id="monospace_size"
-                  name="monospace_size"
-                >
-                  <option value="">Default</option>
-                  <option value="16">16</option>
-                  <option value="17">17</option>
-                  <option value="18">18</option>
-                  <option value="19">19</option>
-                  <option value="20">20</option>
-                </select>
-                <select
-                  class="text-6xl w-full"
-                  id="monospace_weight"
-                  name="monospace_weight"
-                >
-                  <option id="monospace_weight_placeholder" value="">
-                    Default
-                  </option>
-                </select>
+                <div class="flex gap-2">
+                  <select class="text-6xl flex-1" id="monospace" name="monospace">
+                    <option id="monospace_placeholder" value="">Default</option>
+                  </select>
+                  <select
+                    class="text-6xl flex-1"
+                    id="monospace_size"
+                    name="monospace_size"
+                  >
+                    <option value="">Default</option>
+                    <option value="16">16</option>
+                    <option value="17">17</option>
+                    <option value="18">18</option>
+                    <option value="19">19</option>
+                    <option value="20">20</option>
+                  </select>
+                  <select
+                    class="text-6xl flex-1"
+                    id="monospace_weight"
+                    name="monospace_weight"
+                  >
+                    <option id="monospace_weight_placeholder" value="">
+                      Default
+                    </option>
+                  </select>
+                </div>
               </div>
             </div>
             <br /><br /><br />
@@ -226,74 +242,96 @@
               <!-- Serif -->
               <div class="flex flex-col gap-2">
                 <label class="font-serif" for="serif">Serif</label>
-                <select class="w-full" id="global_serif" name="serif">
-                  <option id="global_serif_placeholder" value="">Default</option>
-                </select>
-                <select id="global_serif_size" name="global_serif_size" class="w-full">
-                  <option value="">Default</option>
-                  <option value="16">16</option>
-                  <option value="17">17</option>
-                  <option value="18">18</option>
-                  <option value="19">19</option>
-                  <option value="20">20</option>
-                </select>
-                <select id="global_serif_weight" name="global_serif_weight" class="w-full">
-                  <option id="global_serif_weight_placeholder" value="">
-                    Default
-                  </option>
-                </select>
+                <div class="flex gap-2">
+                  <select class="flex-1" id="global_serif" name="serif">
+                    <option id="global_serif_placeholder" value="">Default</option>
+                  </select>
+                  <select
+                    id="global_serif_size"
+                    name="global_serif_size"
+                    class="flex-1"
+                  >
+                    <option value="">Default</option>
+                    <option value="16">16</option>
+                    <option value="17">17</option>
+                    <option value="18">18</option>
+                    <option value="19">19</option>
+                    <option value="20">20</option>
+                  </select>
+                  <select
+                    id="global_serif_weight"
+                    name="global_serif_weight"
+                    class="flex-1"
+                  >
+                    <option id="global_serif_weight_placeholder" value="">
+                      Default
+                    </option>
+                  </select>
+                </div>
               </div>
               <!-- Sans-serif -->
               <div class="flex flex-col gap-2">
                 <label class="font-sans" for="sans_serif">Sans-serif</label>
-                <select id="global_sans_serif" name="sans_serif" class="w-full">
-                  <option id="global_sans_serif_placeholder" value="">
-                    Default
-                  </option>
-                </select>
-                <select id="global_sans_serif_size" name="global_sans_serif_size" class="w-full">
-                  <option value="">Default</option>
-                  <option value="16">16</option>
-                  <option value="17">17</option>
-                  <option value="18">18</option>
-                  <option value="19">19</option>
-                  <option value="20">20</option>
-                </select>
-                <select
-                  id="global_sans_serif_weight"
-                  name="global_sans_serif_weight"
-                  class="w-full"
-                >
-                  <option id="global_sans_serif_weight_placeholder" value="">
-                    Default
-                  </option>
-                </select>
+                <div class="flex gap-2">
+                  <select id="global_sans_serif" name="sans_serif" class="flex-1">
+                    <option id="global_sans_serif_placeholder" value="">
+                      Default
+                    </option>
+                  </select>
+                  <select
+                    id="global_sans_serif_size"
+                    name="global_sans_serif_size"
+                    class="flex-1"
+                  >
+                    <option value="">Default</option>
+                    <option value="16">16</option>
+                    <option value="17">17</option>
+                    <option value="18">18</option>
+                    <option value="19">19</option>
+                    <option value="20">20</option>
+                  </select>
+                  <select
+                    id="global_sans_serif_weight"
+                    name="global_sans_serif_weight"
+                    class="flex-1"
+                  >
+                    <option id="global_sans_serif_weight_placeholder" value="">
+                      Default
+                    </option>
+                  </select>
+                </div>
               </div>
               <!-- Monospace -->
               <div class="flex flex-col gap-2">
                 <label class="font-mono" for="monospace">Monospace</label>
-                <select id="global_monospace" name="monospace" class="w-full">
-                  <option id="global_monospace_placeholder" value="">
-                    Default
-                  </option>
-                </select>
-                <select id="global_monospace_size" name="global_monospace_size" class="w-full">
-                  <option value="">Default</option>
-                  <option value="16">16</option>
-                  <option value="17">17</option>
-                  <option value="18">18</option>
-                  <option value="19">19</option>
-                  <option value="20">20</option>
-                </select>
-                <select
-                  id="global_monospace_weight"
-                  name="global_monospace_weight"
-                  class="w-full"
-                >
-                  <option id="global_monospace_weight_placeholder" value="">
-                    Default
-                  </option>
-                </select>
+                <div class="flex gap-2">
+                  <select id="global_monospace" name="monospace" class="flex-1">
+                    <option id="global_monospace_placeholder" value="">
+                      Default
+                    </option>
+                  </select>
+                  <select
+                    id="global_monospace_size"
+                    name="global_monospace_size"
+                    class="flex-1"
+                  >
+                    <option value="">Default</option>
+                    <option value="16">16</option>
+                    <option value="17">17</option>
+                    <option value="18">18</option>
+                    <option value="19">19</option>
+                    <option value="20">20</option>
+                  </select>
+                  <select
+                    id="global_monospace_weight"
+                    name="global_monospace_weight"
+                    class="flex-1"
+                  >
+                    <option id="global_monospace_weight_placeholder" value="">
+                      Default
+                    </option>
+                  </select>
+                </div>
               </div>
             </div>
             <br />


### PR DESCRIPTION
## Summary
- Group font, size, and weight dropdowns into a single row under each font family label
- Apply same row-based layout to global settings font selectors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689854865e1c83259beaf6ce7ba53c72