### PR TITLE
Split global font settings into individual rows

### DIFF
--- a/popup/popup.html
+++ b/popup/popup.html
@@ -244,102 +244,100 @@
               <!-- Serif -->
               <div class="flex flex-col gap-2">
                 <label class="font-serif" for="serif">Serif</label>
-                <div class="flex gap-2">
-                  <select class="flex-1" id="global_serif" name="serif">
-                    <option id="global_serif_placeholder" value="">
-                      Default
-                    </option>
-                  </select>
-                  <select
-                    id="global_serif_size"
-                    name="global_serif_size"
-                    class="flex-1"
-                  >
-                    <option value="">Default</option>
-                    <option value="16">16</option>
-                    <option value="17">17</option>
-                    <option value="18">18</option>
-                    <option value="19">19</option>
-                    <option value="20">20</option>
-                  </select>
-                  <select
-                    id="global_serif_weight"
-                    name="global_serif_weight"
-                    class="flex-1"
-                  >
-                    <option id="global_serif_weight_placeholder" value="">
-                      Default
-                    </option>
-                  </select>
-                </div>
+                <select class="text-6xl w-full" id="global_serif" name="serif">
+                  <option id="global_serif_placeholder" value="">
+                    Default
+                  </option>
+                </select>
+                <select
+                  class="text-6xl w-full"
+                  id="global_serif_size"
+                  name="global_serif_size"
+                >
+                  <option value="">Default</option>
+                  <option value="16">16</option>
+                  <option value="17">17</option>
+                  <option value="18">18</option>
+                  <option value="19">19</option>
+                  <option value="20">20</option>
+                </select>
+                <select
+                  class="text-6xl w-full"
+                  id="global_serif_weight"
+                  name="global_serif_weight"
+                >
+                  <option id="global_serif_weight_placeholder" value="">
+                    Default
+                  </option>
+                </select>
               </div>
               <!-- Sans-serif -->
               <div class="flex flex-col gap-2">
                 <label class="font-sans" for="sans_serif">Sans-serif</label>
-                <div class="flex gap-2">
-                  <select
-                    id="global_sans_serif"
-                    name="sans_serif"
-                    class="flex-1"
-                  >
-                    <option id="global_sans_serif_placeholder" value="">
-                      Default
-                    </option>
-                  </select>
-                  <select
-                    id="global_sans_serif_size"
-                    name="global_sans_serif_size"
-                    class="flex-1"
-                  >
-                    <option value="">Default</option>
-                    <option value="16">16</option>
-                    <option value="17">17</option>
-                    <option value="18">18</option>
-                    <option value="19">19</option>
-                    <option value="20">20</option>
-                  </select>
-                  <select
-                    id="global_sans_serif_weight"
-                    name="global_sans_serif_weight"
-                    class="flex-1"
-                  >
-                    <option id="global_sans_serif_weight_placeholder" value="">
-                      Default
-                    </option>
-                  </select>
-                </div>
+                <select
+                  class="text-6xl w-full"
+                  id="global_sans_serif"
+                  name="sans_serif"
+                >
+                  <option id="global_sans_serif_placeholder" value="">
+                    Default
+                  </option>
+                </select>
+                <select
+                  class="text-6xl w-full"
+                  id="global_sans_serif_size"
+                  name="global_sans_serif_size"
+                >
+                  <option value="">Default</option>
+                  <option value="16">16</option>
+                  <option value="17">17</option>
+                  <option value="18">18</option>
+                  <option value="19">19</option>
+                  <option value="20">20</option>
+                </select>
+                <select
+                  class="text-6xl w-full"
+                  id="global_sans_serif_weight"
+                  name="global_sans_serif_weight"
+                >
+                  <option id="global_sans_serif_weight_placeholder" value="">
+                    Default
+                  </option>
+                </select>
               </div>
               <!-- Monospace -->
               <div class="flex flex-col gap-2">
                 <label class="font-mono" for="monospace">Monospace</label>
-                <div class="flex gap-2">
-                  <select id="global_monospace" name="monospace" class="flex-1">
-                    <option id="global_monospace_placeholder" value="">
-                      Default
-                    </option>
-                  </select>
-                  <select
-                    id="global_monospace_size"
-                    name="global_monospace_size"
-                    class="flex-1"
-                  >
-                    <option value="">Default</option>
-                    <option value="16">16</option>
-                    <option value="17">17</option>
-                    <option value="18">18</option>
-                    <option value="19">19</option>
-                    <option value="20">20</option>
-                  </select>
-                  <select
-                    id="global_monospace_weight"
-                    name="global_monospace_weight"
-                    class="flex-1"
-                  >
-                    <option id="global_monospace_weight_placeholder" value="">
-                      Default
-                    </option>
-                  </select>
-                </div>
+                <select
+                  class="text-6xl w-full"
+                  id="global_monospace"
+                  name="monospace"
+                >
+                  <option id="global_monospace_placeholder" value="">
+                    Default
+                  </option>
+                </select>
+                <select
+                  class="text-6xl w-full"
+                  id="global_monospace_size"
+                  name="global_monospace_size"
+                >
+                  <option value="">Default</option>
+                  <option value="16">16</option>
+                  <option value="17">17</option>
+                  <option value="18">18</option>
+                  <option value="19">19</option>
+                  <option value="20">20</option>
+                </select>
+                <select
+                  class="text-6xl w-full"
+                  id="global_monospace_weight"
+                  name="global_monospace_weight"
+                >
+                  <option id="global_monospace_weight_placeholder" value="">
+                    Default
+                  </option>
+                </select>
               </div>
             </div>
             <br />


### PR DESCRIPTION
## Summary
- Adjust global settings UI layout so each font, size, and weight selection appears on its own row for serif, sans-serif, and monospace families

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: web-ext: not found)*
- `npx tailwindcss -i input.css -o ./popup/popup.css`


------
https://chatgpt.com/codex/tasks/task_e_68985c0975d88325a3d8025916d3a539